### PR TITLE
Fixes for 5.1

### DIFF
--- a/src/Console/PublishAssetsCommand.php
+++ b/src/Console/PublishAssetsCommand.php
@@ -29,7 +29,7 @@ class PublishAssetsCommand extends Command
         $this->info("Publishing assets files");
         $this->call('vendor:publish', array(
             '--provider' => 'Darkaonline\L5Swagger\L5SwaggerServiceProvider',
-            '--tag' => 'assets'
+            '--tag' => ['assets']
         ));
     }
 

--- a/src/Console/PublishConfigCommand.php
+++ b/src/Console/PublishConfigCommand.php
@@ -29,7 +29,7 @@ class PublishConfigCommand extends Command
         $this->info("Publish config files");
         $this->call('vendor:publish', array(
             '--provider' => 'Darkaonline\L5Swagger\L5SwaggerServiceProvider',
-            '--tag' => 'config'
+            '--tag' => ['config']
         ));
     }
 

--- a/src/Console/PublishViewsCommand.php
+++ b/src/Console/PublishViewsCommand.php
@@ -29,7 +29,7 @@ class PublishViewsCommand extends Command
         $this->info("Publishing view files");
         $this->call('vendor:publish', array(
             '--provider' => 'Darkaonline\L5Swagger\L5SwaggerServiceProvider',
-            '--tag' => 'views'
+            '--tag' => ['views']
         ));
     }
 


### PR DESCRIPTION
See [this](https://github.com/laravel/framework/issues/9586).

Currently with this code on Laravel 5.1 you get a:

     [ErrorException]
     Invalid argument supplied for foreach()

Error due to it interpreting that tags as a string instead of an array. This forces it to make it an array and fixed the error. 