### PR TITLE
Make docExpansion configurable

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -176,6 +176,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Edit to change layout of GUI ( 'none', 'list' or 'full')
+    |--------------------------------------------------------------------------
+    */
+
+    'docExpansion' => env('L5_SWAGGER_DOC_EXPANSION', 'none'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Uncomment to pass the validatorUrl parameter to SwaggerUi init on the JS
     | side.  A null value here disables validation.  A string will override
     | the default url.  If not specified, behavior is default and validation

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -89,7 +89,7 @@ if (app()->environment() != 'testing') {
                 onFailure: function(data) {
                     console.log("Unable to Load SwaggerUI");
                 },
-                docExpansion: "none",
+                docExpansion: {!! isset($docExpansion) ? '"' . $docExpansion . '"' : '"none"' !!},
                 jsonEditor: false,
                 apisSorter: "alpha",
                 defaultModelRendering: 'schema',

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -70,7 +70,7 @@ class SwaggerController extends BaseController
                 'secure'             => Request::secure(),
                 'urlToDocs'          => route('l5-swagger.docs', config('l5-swagger.paths.docs_json', 'api-docs.json')),
                 'requestHeaders'     => config('l5-swagger.headers.request'),
-                'docExpansion'       => config('l5-swagger.docExpansion')
+                'docExpansion'       => config('l5-swagger.docExpansion'),
             ], $extras),
             200
         );

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -70,6 +70,7 @@ class SwaggerController extends BaseController
                 'secure'             => Request::secure(),
                 'urlToDocs'          => route('l5-swagger.docs', config('l5-swagger.paths.docs_json', 'api-docs.json')),
                 'requestHeaders'     => config('l5-swagger.headers.request'),
+                'docExpansion'       => config('l5-swagger.docExpansion')
             ], $extras),
             200
         );


### PR DESCRIPTION
Currently everything is always collapsed when going to the documentation. Setting this option can show it as a list ( or everything uncollapsed ) right away.