### PR TITLE
Using configuration base path to update Swagger base path

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -19,6 +19,7 @@ class Generator
             File::makeDirectory($docDir);
             $excludeDirs = config('l5-swagger.paths.excludes');
             $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
+            $swagger->basePath = config('l5-swagger.paths.base');
 
             $filename = $docDir.'/'.config('l5-swagger.paths.docs_json', 'api-docs.json');
             $swagger->saveAs($filename);


### PR DESCRIPTION
Noticed that the 'base' path configuration option under 'paths' wasn't being used anywhere, so added this in after the annotations have been scanned but prior to saving the JSON.

Realised that without updating the original package (I think) it would be difficult to add another Processor to augment the basePath annotation on the Swagger object there, so unfortunately this is a less-elegant solution.