### PR TITLE
Support for Oauth2 redirect (implicit/accessCode)

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -79,6 +79,7 @@ window.onload = function() {
     operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
     configUrl: {!! isset($additionalConfigUrl) ? '"' . $additionalConfigUrl . '"' : 'null' !!},
     validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+    oauth2RedirectUrl: "{{ l5_swagger_asset('oauth2-redirect.html') }}",
 
     presets: [
       SwaggerUIBundle.presets.apis,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,6 +17,7 @@ if (! function_exists('swagger_ui_dist_path')) {
             'swagger-ui-bundle.js',
             'swagger-ui.js',
             'swagger-ui.css',
+            'oauth2-redirect.html'
         ];
 
         $path = base_path('vendor/swagger-api/swagger-ui/dist/');

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,7 +17,7 @@ if (! function_exists('swagger_ui_dist_path')) {
             'swagger-ui-bundle.js',
             'swagger-ui.js',
             'swagger-ui.css',
-            'oauth2-redirect.html'
+            'oauth2-redirect.html',
         ];
 
         $path = base_path('vendor/swagger-api/swagger-ui/dist/');

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -55,4 +55,12 @@ class RoutesTest extends TestCase
             ->assertSee('.swagger-ui')
             ->isOk();
     }
+
+    /** @test */
+    public function userCanAccessOauth2Redirect()
+    {
+        $this->get(l5_swagger_asset('oauth2-redirect.html'))
+            ->assertSee('<script>')
+            ->isOk();
+    }
 }


### PR DESCRIPTION
In order to make  OAuth2 authorization in the Swagger UI work, the `oauth2RedirectUrl` parameter needs to be set correctly (which defaults to `localhost...`). Therefore the `oauth2-redirect.html` needs to be available.