### PR TITLE
Upgrade for Laravel 5.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": "^7.0",
-    "laravel/framework": "5.4.*",
+    "laravel/framework": "5.5.*",
     "zircote/swagger-php": "~2.0",
     "swagger-api/swagger-ui": "^3.0"
   },

--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -26,7 +26,7 @@ class GenerateDocsCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Regenerating docs');
         Generator::generateDocs();

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -25,7 +25,7 @@ class PublishCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publishing all files');
         $this->call('vendor:publish', [

--- a/src/Console/PublishConfigCommand.php
+++ b/src/Console/PublishConfigCommand.php
@@ -25,7 +25,7 @@ class PublishConfigCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publish config files');
         $this->call('vendor:publish', [

--- a/src/Console/PublishViewsCommand.php
+++ b/src/Console/PublishViewsCommand.php
@@ -25,7 +25,7 @@ class PublishViewsCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publishing view files');
         $this->call('vendor:publish', [


### PR DESCRIPTION
* Replaced deprecated fire() calls with handle() in console commands.
* Upgraded dependency versions to match Laravel 5.5.

Fork with 5.5 support is working fine in my Laravel 5.5 project.