### PR TITLE
Add package auto discovery feature in Laravel 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ or open your `config/app.php` and add this line in `providers` section
 ```php
 L5Swagger\L5SwaggerServiceProvider::class,
 ```
+
+For Laravel 5.5, no need to manually add `L5SwaggerServiceProvider` into config. It uses package auto discovery feature.
+
 Changes in 5.0
 ============
 - Swagger UI 3.

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,13 @@
       "Tests\\": "tests"
     }
   },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "L5Swagger\\L5SwaggerServiceProvider"
+      ]
+    }
+  },
   "minimum-stability": "dev",
   "prefer-stable": true
 }


### PR DESCRIPTION
With this feature, no need to manually add `L5Swagger\L5SwaggerServiceProvider` in config file