### PR TITLE
export ignore developer files for distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
 resources/* linguist-vendored
+.gitattributes   export-ignore
+.gitignore       export-ignore
+README.md        export-ignore
+.codeclimate.yml export-ignore
+.coveralls.yml   export-ignore
+.styleci.yml     export-ignore
+.travis.yml      export-ignore
+/tests/          export-ignore
+phpunit.xml      export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
I noticed your package was a little bloated for production use.
This PR excludes all the unnecessary tests and associated developer service configuration files
which takes up less storage and uses less bandwidth on every `composer require`

Also note I did not `export-ignore` the `LICENSE` despite the fact it isn't strictly necessary to run the code,
because I always include the license even with a package library.