### PR TITLE
fix route precedence

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1,15 +1,15 @@
 <?php
 
-$router->any(config('l5-swagger.routes.docs').'/{jsonFile?}', [
-    'as' => 'l5-swagger.docs',
-    'middleware' => config('l5-swagger.routes.middleware.docs', []),
-    'uses' => '\L5Swagger\Http\Controllers\SwaggerController@docs',
-]);
-
 $router->get(config('l5-swagger.routes.api'), [
     'as' => 'l5-swagger.api',
     'middleware' => config('l5-swagger.routes.middleware.api', []),
     'uses' => '\L5Swagger\Http\Controllers\SwaggerController@api',
+]);
+
+$router->any(config('l5-swagger.routes.docs').'/{jsonFile?}', [
+    'as' => 'l5-swagger.docs',
+    'middleware' => config('l5-swagger.routes.middleware.docs', []),
+    'uses' => '\L5Swagger\Http\Controllers\SwaggerController@docs',
 ]);
 
 $router->get(config('l5-swagger.routes.docs').'/asset/{asset}', [


### PR DESCRIPTION
Consider my configuration:

```php
/*
|--------------------------------------------------------------------------
| Route for accessing api documentation interface
|--------------------------------------------------------------------------
*/

'api' => 'api/v1',

/*
|--------------------------------------------------------------------------
| Route for accessing parsed swagger annotations.
|--------------------------------------------------------------------------
*/

'docs' => 'api/v1',

/*
|--------------------------------------------------------------------------
| File name of the generated json documentation file
|--------------------------------------------------------------------------
*/

'docs_json' => 'open-api-specification.json',
```

This serves the swagger-ui at `/api/v1`,
the json itself at `/api/v1/open-api-specification.json`,
and then I have various endpoints such as `/api/v1/foo` and `/api/v1/bar`
which I feel makes the most sense semantically for the current project.

However, the route named `l5-swagger.docs` is loaded before `l5-swagger.api`
and because the optional parameter `{jsonFile?}` in `l5-swagger.docs`
matches the path first, the route `l5-swagger.api` is unreachable.

This PR merely loads the `l5-swagger.api` route first so it takes precedence.
This is backwards compatible in that if one doesn't use overlapping routes,
then a missing `{jsonFile?}` parameter will load like it always has.
This simply exposes the ability to use overlapping routes.