### PR TITLE
fix laravel version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=7.1.3",
-    "laravel/framework": "5.6.*",
+    "laravel/framework": "5.5.*",
     "zircote/swagger-php": "~2.0|3.*",
     "swagger-api/swagger-ui": "^3.0"
   },


### PR DESCRIPTION
The required laravel version in the 5.5 package is wrong, therefore I cannot update vom 5.5.4 to 5.5.6 where OpenAPI 3.0 is enabled.