### PR TITLE
Fix to make additional_config_url works

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -77,7 +77,7 @@ window.onload = function() {
 
     url: "{!! $urlToDocs !!}",
     operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
-    configUrl: {!! isset($additionalConfigUrl) ? '"' . $additionalConfigUrl . '"' : 'null' !!},
+    configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
     validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
     oauth2RedirectUrl: "{{ route('l5-swagger.oauth2_callback') }}",
 


### PR DESCRIPTION
Change **additionalConfigUrl** to **configUrl** to match parameter name from SwaggerController.php

#### SwaggerController.php
```
'configUrl'          => config('l5-swagger.additional_config_url'),
```

#### index.php
```
configUrl: {!! isset($additionalConfigUrl) ? '"' . $additionalConfigUrl . '"' : 'null' !!},
```