### PR TITLE
Fix: Method generateDocs has 26 lines of code (exceeds 25 allowed). Consider refactoring. 

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -29,7 +29,9 @@ class Generator
                     $swagger->servers = [
                         new Server(['url' => config('l5-swagger.paths.base')]),
                     ];
-                } else {
+                }
+
+                if (config('swagger_version') === '2.0') {
                     $swagger->basePath = config('l5-swagger.paths.base');
                 }
             }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -35,7 +35,7 @@ class Generator
     }
 
     /**
-     * Generate servers section or basePath depending on Swagger version
+     * Generate servers section or basePath depending on Swagger version.
      *
      * @param \Swagger\Annotations\OpenApi $swagger Swagger/OpenAPI instance
      */

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -31,7 +31,7 @@ class Generator
                     ];
                 }
 
-                if (config('swagger_version') === '2.0') {
+                if (config('swagger_version') !== '3.0') {
                     $swagger->basePath = config('l5-swagger.paths.base');
                 }
             }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -25,11 +25,14 @@ class Generator
             $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
 
             if (config('l5-swagger.paths.base') !== null) {
-                if (version_compare(config('l5-swagger.swagger_version'), '3.0', '>=')) {
+                $isVersion3 = version_compare(config('l5-swagger.swagger_version'), '3.0', '>=');
+                if ($isVersion3) {
                     $swagger->servers = [
                         new Server(['url' => config('l5-swagger.paths.base')]),
                     ];
-                } else {
+                }
+
+                if (! $isVersion3) {
                     $swagger->basePath = config('l5-swagger.paths.base');
                 }
             }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -24,24 +24,34 @@ class Generator
             $excludeDirs = config('l5-swagger.paths.excludes');
             $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
 
-            if (config('l5-swagger.paths.base') !== null) {
-                $isVersion3 = version_compare(config('l5-swagger.swagger_version'), '3.0', '>=');
-                if ($isVersion3) {
-                    $swagger->servers = [
-                        new Server(['url' => config('l5-swagger.paths.base')]),
-                    ];
-                }
-
-                if (! $isVersion3) {
-                    $swagger->basePath = config('l5-swagger.paths.base');
-                }
-            }
+            self::generateServers($swagger);
 
             $filename = $docDir.'/'.config('l5-swagger.paths.docs_json', 'api-docs.json');
             $swagger->saveAs($filename);
 
             $security = new SecurityDefinitions();
             $security->generate($filename);
+        }
+    }
+
+    /**
+     * Generate servers section or basePath depending on Swagger version
+     *
+     * @param \Swagger\Annotations\OpenApi $swagger Swagger/OpenAPI instance
+     */
+    protected static function generateServers($swagger)
+    {
+        if (config('l5-swagger.paths.base') !== null) {
+            $isVersion3 = version_compare(config('l5-swagger.swagger_version'), '3.0', '>=');
+            if ($isVersion3) {
+                $swagger->servers = [
+                    new Server(['url' => config('l5-swagger.paths.base')]),
+                ];
+            }
+
+            if (! $isVersion3) {
+                $swagger->basePath = config('l5-swagger.paths.base');
+            }
         }
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -25,13 +25,11 @@ class Generator
             $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
 
             if (config('l5-swagger.paths.base') !== null) {
-                if (config('swagger_version') === '3.0') {
+                if (version_compare(config('l5-swagger.swagger_version'), '3.0', '>=')) {
                     $swagger->servers = [
                         new Server(['url' => config('l5-swagger.paths.base')]),
                     ];
-                }
-
-                if (config('swagger_version') !== '3.0') {
+                } else {
                     $swagger->basePath = config('l5-swagger.paths.base');
                 }
             }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -4,6 +4,7 @@ namespace L5Swagger;
 
 use File;
 use Config;
+use Swagger\Annotations\Server;
 
 class Generator
 {
@@ -24,7 +25,13 @@ class Generator
             $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
 
             if (config('l5-swagger.paths.base') !== null) {
-                $swagger->basePath = config('l5-swagger.paths.base');
+                if (config('swagger_version') === '3.0') {
+                    $swagger->servers = [
+                        new Server(['url' => config('l5-swagger.paths.base')]),
+                    ];
+                } else {
+                    $swagger->basePath = config('l5-swagger.paths.base');
+                }
             }
 
             $filename = $docDir.'/'.config('l5-swagger.paths.docs_json', 'api-docs.json');


### PR DESCRIPTION
I've just realized that new warning appeared. Please review proposed fix.