### PR TITLE
Respect always_generate option when generating OpenAPI file

### DIFF
--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -22,7 +22,7 @@ class SwaggerController extends BaseController
         $filePath = config('l5-swagger.paths.docs').'/'.
             (! is_null($jsonFile) ? $jsonFile : config('l5-swagger.paths.docs_json', 'api-docs.json'));
 
-        if (! File::exists($filePath)) {
+        if (config('l5-swagger.generate_always') || ! File::exists($filePath)) {
             try {
                 Generator::generateDocs();
             } catch (\Exception $e) {
@@ -44,10 +44,6 @@ class SwaggerController extends BaseController
      */
     public function api()
     {
-        if (config('l5-swagger.generate_always')) {
-            Generator::generateDocs();
-        }
-
         if ($proxy = config('l5-swagger.proxy')) {
             if (! is_array($proxy)) {
                 $proxy = [$proxy];


### PR DESCRIPTION
Currently, the OpenAPI file is only regenerated when accessing the Swagger UI route (SwaggerController::api).  Since I use ReDoc instead of Swagger UI, I still have to generate my docs manually after every change.  This simply moves the doc generation decision from the UI route to the openapi route.