### PR TITLE
Fix OpenAPI JSON pretty-printing

### DIFF
--- a/src/SecurityDefinitions.php
+++ b/src/SecurityDefinitions.php
@@ -26,7 +26,10 @@ class SecurityDefinitions
                 $this->generateOpenApi($documentation, $securityConfig) :
                 $this->generateSwaggerApi($documentation, $securityConfig);
 
-            file_put_contents($filename, $documentation->toJson());
+            file_put_contents(
+                $filename,
+                $documentation->toJson(JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            );
         }
     }
 


### PR DESCRIPTION
Passes flags that match what swagger-php provides by default to json_encode() to ensure output is pretty-printed, even after adding security definitions. Previously the output was encoded as pretty-printed JSON, pulled back in, then re-encoded with no flags (and thus no newlines).

This will help anyone who'd rather not have a conflict on generated specs if they make any changes at all in e.g. two branches.