### PR TITLE
Fix Request class not found exception

### DIFF
--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -2,10 +2,11 @@
 
 namespace L5Swagger\Http\Controllers;
 
-use File;
-use Request;
-use Response;
 use L5Swagger\Generator;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Response;
+use L5Swagger\Exceptions\L5SwaggerException;
 use Illuminate\Routing\Controller as BaseController;
 
 class SwaggerController extends BaseController
@@ -15,7 +16,7 @@ class SwaggerController extends BaseController
      *
      * @param string $jsonFile
      *
-     * @return \Response
+     * @return \Illuminate\Http\Response
      */
     public function docs($jsonFile = null)
     {
@@ -40,7 +41,7 @@ class SwaggerController extends BaseController
     /**
      * Display Swagger API page.
      *
-     * @return \Response
+     * @return \Illuminate\Http\Response
      */
     public function api()
     {
@@ -48,7 +49,7 @@ class SwaggerController extends BaseController
             if (! is_array($proxy)) {
                 $proxy = [$proxy];
             }
-            Request::setTrustedProxies($proxy, \Illuminate\Http\Request::HEADER_X_FORWARDED_ALL);
+            \Illuminate\Http\Request::setTrustedProxies($proxy, \Illuminate\Http\Request::HEADER_X_FORWARDED_ALL);
         }
 
         // Need the / at the end to avoid CORS errors on Homestead systems.
@@ -70,9 +71,10 @@ class SwaggerController extends BaseController
      * Display Oauth2 callback pages.
      *
      * @return string
+     * @throws L5SwaggerException
      */
     public function oauth2Callback()
     {
-        return \File::get(swagger_ui_dist_path('oauth2-redirect.html'));
+        return File::get(swagger_ui_dist_path('oauth2-redirect.html'));
     }
 }

--- a/src/L5SwaggerServiceProvider.php
+++ b/src/L5SwaggerServiceProvider.php
@@ -29,9 +29,7 @@ class L5SwaggerServiceProvider extends ServiceProvider
         ], 'views');
 
         //Include routes
-        \Route::group(['namespace' => 'L5Swagger'], function ($router) {
-            require __DIR__.'/routes.php';
-        });
+        $this->loadRoutesFrom(__DIR__.'/routes.php');
 
         //Register commands
         $this->commands([GenerateDocsCommand::class]);

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,25 +1,30 @@
 <?php
 
-$router->get(config('l5-swagger.routes.api'), [
-    'as' => 'l5-swagger.api',
-    'middleware' => config('l5-swagger.routes.middleware.api', []),
-    'uses' => '\L5Swagger\Http\Controllers\SwaggerController@api',
-]);
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Route;
 
-$router->any(config('l5-swagger.routes.docs').'/{jsonFile?}', [
-    'as' => 'l5-swagger.docs',
-    'middleware' => config('l5-swagger.routes.middleware.docs', []),
-    'uses' => '\L5Swagger\Http\Controllers\SwaggerController@docs',
-]);
+Route::group(['namespace' => 'L5Swagger'], function (Router $router) {
+    $router->get(config('l5-swagger.routes.api'), [
+        'as' => 'l5-swagger.api',
+        'middleware' => config('l5-swagger.routes.middleware.api', []),
+        'uses' => '\L5Swagger\Http\Controllers\SwaggerController@api',
+    ]);
 
-$router->get(config('l5-swagger.routes.docs').'/asset/{asset}', [
-    'as' => 'l5-swagger.asset',
-    'middleware' => config('l5-swagger.routes.middleware.asset', []),
-    'uses' => '\L5Swagger\Http\Controllers\SwaggerAssetController@index',
-]);
+    $router->any(config('l5-swagger.routes.docs').'/{jsonFile?}', [
+        'as' => 'l5-swagger.docs',
+        'middleware' => config('l5-swagger.routes.middleware.docs', []),
+        'uses' => '\L5Swagger\Http\Controllers\SwaggerController@docs',
+    ]);
 
-$router->get(config('l5-swagger.routes.oauth2_callback'), [
-    'as' => 'l5-swagger.oauth2_callback',
-    'middleware' => config('l5-swagger.routes.middleware.oauth2_callback', []),
-    'uses' => '\L5Swagger\Http\Controllers\SwaggerController@oauth2Callback',
-]);
+    $router->get(config('l5-swagger.routes.docs').'/asset/{asset}', [
+        'as' => 'l5-swagger.asset',
+        'middleware' => config('l5-swagger.routes.middleware.asset', []),
+        'uses' => '\L5Swagger\Http\Controllers\SwaggerAssetController@index',
+    ]);
+
+    $router->get(config('l5-swagger.routes.oauth2_callback'), [
+        'as' => 'l5-swagger.oauth2_callback',
+        'middleware' => config('l5-swagger.routes.middleware.oauth2_callback', []),
+        'uses' => '\L5Swagger\Http\Controllers\SwaggerController@oauth2Callback',
+    ]);
+});


### PR DESCRIPTION
`Class 'Request' not found` exception was raised when accessing the documentation.
It looks that not having Facade namespace make this happen.

I guess it will be the same for `File` and `Response` so I did the same for it.

The problem occured on Laravel 5.8.31 with php 7.2