### PR TITLE
Error log when throwing exception

### DIFF
--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -2,6 +2,7 @@
 
 namespace L5Swagger\Http\Controllers;
 
+use Log;
 use L5Swagger\Generator;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Request;
@@ -34,6 +35,7 @@ class SwaggerController extends BaseController
             try {
                 Generator::generateDocs();
             } catch (\Exception $e) {
+                Log::error($e);
                 abort(404, 'Cannot find '.$filePath.' and cannot be generated.');
             }
         }

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -2,8 +2,8 @@
 
 namespace L5Swagger\Http\Controllers;
 
-use Log;
 use L5Swagger\Generator;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;


### PR DESCRIPTION
If we don't have permissions to write file to our docs directory we cant 
see that error, **but** when we use command to generate file it write only "Regenerating docs" and thats all.