### PR TITLE
Support symfony/yaml 5.x (not tested)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "laravel/framework": "^6.0",
     "zircote/swagger-php": "~2.0|3.*",
     "swagger-api/swagger-ui": "^3.0",
-    "symfony/yaml": "^4.1"
+    "symfony/yaml": "^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "8.*",


### PR DESCRIPTION
Fixes

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: don't install darkaonline/l5-swagger 6.0.3
    - Conclusion: don't install darkaonline/l5-swagger 6.0.2
    - Conclusion: don't install darkaonline/l5-swagger 6.0.1
    - Conclusion: remove symfony/yaml v5.0.1
    - Installation request for darkaonline/l5-swagger ^6.0 -> satisfiable by darkaonline/l5-swagger[6.0, 6.0.1, 6.0.2, 6.0.3].
...
```

Edit: for Laravel 6.x only?