### PR TITLE
Generator use Dependency Injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
     "laravel": {
       "providers": [
         "L5Swagger\\L5SwaggerServiceProvider"
-      ]
+      ],
+      "aliases": {
+        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+      }
     }
   },
   "minimum-stability": "dev",

--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -8,6 +8,18 @@ use L5Swagger\Generator;
 class GenerateDocsCommand extends Command
 {
     /**
+     * @var L5Swagger\Generator
+     */
+    protected $generator;
+
+    public function __construct(Generator $generator)
+    {
+        parent::__construct();
+
+        $this->generator = $generator;
+    }
+
+    /**
      * The console command name.
      *
      * @var string
@@ -29,6 +41,6 @@ class GenerateDocsCommand extends Command
     public function handle()
     {
         $this->info('Regenerating docs');
-        Generator::generateDocs();
+        $this->generator->generateDocs();
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -48,20 +48,41 @@ class Generator
      */
     protected $yamlCopyRequired;
 
-    public function __construct()
-    {
-        $this->annotationsDir = config('l5-swagger.paths.annotations');
-        $this->docDir = config('l5-swagger.paths.docs');
-        $this->docsFile = $this->docDir.'/'.config('l5-swagger.paths.docs_json', 'api-docs.json');
-        $this->yamlDocsFile = $this->docDir.'/'.config('l5-swagger.paths.docs_yaml', 'api-docs.yaml');
-        $this->excludedDirs = config('l5-swagger.paths.excludes');
-        $this->constants = config('l5-swagger.constants') ?: [];
-        $this->yamlCopyRequired = config('l5-swagger.generate_yaml_copy', false);
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var string
+     */
+    protected $swaggerVersion;
+
+    public function __construct(
+        $annotationsDir,
+        $docDir,
+        $docsFile,
+        $yamlDocsFile,
+        $excludedDirs,
+        $constants,
+        $yamlCopyRequired,
+        $basePath,
+        $swaggerVersion
+    ) {
+        $this->annotationsDir = $annotationsDir;
+        $this->docDir = $docDir;
+        $this->docsFile = $docsFile;
+        $this->yamlDocsFile = $yamlDocsFile;
+        $this->excludedDirs = $excludedDirs;
+        $this->constants = $constants;
+        $this->yamlCopyRequired = $yamlCopyRequired;
+        $this->basePath = $basePath;
+        $this->swaggerVersion = $swaggerVersion;
     }
 
-    public static function generateDocs()
+    public function generateDocs()
     {
-        (new static)->prepareDirectory()
+        $this->prepareDirectory()
             ->defineConstants()
             ->scanFilesForDocumentation()
             ->populateServers()
@@ -137,17 +158,17 @@ class Generator
      */
     protected function populateServers()
     {
-        if (config('l5-swagger.paths.base') !== null) {
+        if ($this->basePath !== null) {
             if ($this->isOpenApi()) {
                 if (! is_array($this->swagger->servers)) {
                     $this->swagger->servers = [];
                 }
 
-                $this->swagger->servers[] = new \OpenApi\Annotations\Server(['url' => config('l5-swagger.paths.base')]);
+                $this->swagger->servers[] = new \OpenApi\Annotations\Server(['url' => $this->basePath]);
             }
 
             if (! $this->isOpenApi()) {
-                $this->swagger->basePath = config('l5-swagger.paths.base');
+                $this->swagger->basePath = $this->basePath;
             }
         }
 
@@ -191,6 +212,6 @@ class Generator
      */
     protected function isOpenApi()
     {
-        return version_compare(config('l5-swagger.swagger_version'), '3.0', '>=');
+        return version_compare($this->swaggerVersion, '3.0', '>=');
     }
 }

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -13,6 +13,16 @@ use L5Swagger\Generator;
 class SwaggerController extends BaseController
 {
     /**
+     * @var L5Swagger\Generator
+     */
+    protected $generator;
+
+    public function __construct(Generator $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    /**
      * Dump api-docs content endpoint. Supports dumping a json, or yaml file.
      *
      * @param string $file
@@ -33,7 +43,7 @@ class SwaggerController extends BaseController
 
         if (config('l5-swagger.generate_always') || ! File::exists($filePath)) {
             try {
-                Generator::generateDocs();
+                $this->generator->generateDocs();
             } catch (\Exception $e) {
                 Log::error($e);
 

--- a/src/L5SwaggerFacade.php
+++ b/src/L5SwaggerFacade.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace L5Swagger;
+
+use Illuminate\Support\Facades\Facade;
+
+class L5SwaggerFacade extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return Generator::class;
+    }
+}

--- a/src/L5SwaggerServiceProvider.php
+++ b/src/L5SwaggerServiceProvider.php
@@ -45,8 +45,34 @@ class L5SwaggerServiceProvider extends ServiceProvider
         $configPath = __DIR__.'/../config/l5-swagger.php';
         $this->mergeConfigFrom($configPath, 'l5-swagger');
 
-        $this->app->singleton('command.l5-swagger.generate', function () {
-            return new GenerateDocsCommand();
+        $this->app->singleton('command.l5-swagger.generate', function ($app) {
+            return new GenerateDocsCommand(
+                $app->make(Generator::class)
+            );
+        });
+
+        $this->app->bind(Generator::class, function ($app) {
+            $annotationsDir = config('l5-swagger.paths.annotations');
+            $docDir = config('l5-swagger.paths.docs');
+            $docsFile = $docDir.'/'.config('l5-swagger.paths.docs_json', 'api-docs.json');
+            $yamlDocsFile = $docDir.'/'.config('l5-swagger.paths.docs_yaml', 'api-docs.yaml');
+            $excludedDirs = config('l5-swagger.paths.excludes');
+            $constants = config('l5-swagger.constants') ?: [];
+            $yamlCopyRequired = config('l5-swagger.generate_yaml_copy', false);
+            $basePath = config('l5-swagger.paths.base');
+            $swaggerVersion = config('l5-swagger.swagger_version');
+
+            return new Generator(
+                $annotationsDir,
+                $docDir,
+                $docsFile,
+                $yamlDocsFile,
+                $excludedDirs,
+                $constants,
+                $yamlCopyRequired,
+                $basePath,
+                $swaggerVersion
+            );
         });
     }
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use L5Swagger\Exceptions\L5SwaggerException;
-use L5Swagger\Generator;
 
 class GeneratorTest extends TestCase
 {
@@ -17,7 +16,7 @@ class GeneratorTest extends TestCase
 
         $this->expectException(L5SwaggerException::class);
 
-        Generator::generateDocs();
+        $this->generator->generateDocs();
 
         chmod(config('l5-swagger.paths.docs'), 0777);
     }
@@ -27,7 +26,7 @@ class GeneratorTest extends TestCase
     {
         $this->setAnnotationsPath();
 
-        Generator::generateDocs();
+        $this->generator->generateDocs();
 
         $this->assertTrue(file_exists($this->jsonDocsFile()));
         $this->assertTrue(file_exists($this->yamlDocsFile()));
@@ -56,7 +55,7 @@ class GeneratorTest extends TestCase
         $cfg['paths']['base'] = '/new_path/is/here';
         config(['l5-swagger' => $cfg]);
 
-        Generator::generateDocs();
+        $this->generator->generateDocs();
 
         $this->assertTrue(file_exists($this->jsonDocsFile()));
 
@@ -85,7 +84,7 @@ class GeneratorTest extends TestCase
         $cfg['swagger_version'] = '3.0';
         config(['l5-swagger' => $cfg]);
 
-        tap(new Generator)->generateDocs();
+        $this->generator->generateDocs();
 
         $this->assertTrue(file_exists($this->jsonDocsFile()));
 

--- a/tests/SecurityDefinitionsTest.php
+++ b/tests/SecurityDefinitionsTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use L5Swagger\Generator;
-
 class SecurityDefinitionsTest extends TestCase
 {
     /** @test */
@@ -26,7 +24,7 @@ class SecurityDefinitionsTest extends TestCase
         $cfg['swagger_version'] = '2.0';
         config(['l5-swagger' => $cfg]);
 
-        tap(new Generator)->generateDocs();
+        $this->generator->generateDocs();
 
         $this->assertTrue(file_exists($this->jsonDocsFile()));
 
@@ -56,7 +54,7 @@ class SecurityDefinitionsTest extends TestCase
         $cfg['swagger_version'] = '3.0';
         config(['l5-swagger' => $cfg]);
 
-        tap(new Generator)->generateDocs();
+        $this->generator->generateDocs();
 
         $this->assertTrue(file_exists($this->jsonDocsFile()));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,14 +2,19 @@
 
 namespace Tests;
 
+use L5Swagger\Generator;
 use L5Swagger\L5SwaggerServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 class TestCase extends OrchestraTestCase
 {
+    protected $generator;
+
     public function setUp() :void
     {
         parent::setUp();
+
+        $this->makeGenerator();
 
         $this->copyAssets();
     }
@@ -82,6 +87,13 @@ class TestCase extends OrchestraTestCase
         $cfg['constants']['L5_SWAGGER_CONST_HOST'] = 'http://my-default-host.com';
 
         config(['l5-swagger' => $cfg]);
+
+        $this->makeGenerator();
+    }
+
+    protected function makeGenerator()
+    {
+        $this->generator = $this->app->make(Generator::class);
     }
 
     protected function setCustomDocsFileName($fileName)


### PR DESCRIPTION
This PR uses the Service Provider to register de `Generator` and inject the config as dependency, this way we can create multiple instances of the `Generator` with different options, I'm hoping it'll help to solve this issue #149 

The `Generator` method `generateDocs()` is not static anymore, but I created a Facade as `L5Swagger ` so you can call `L5Swagger::generateDocs()`.