### PR TITLE
Issue #245: make the Yaml generator generate an empty array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "laravel/framework": "^6.0",
     "zircote/swagger-php": "~2.0|3.*",
     "swagger-api/swagger-ui": "^3.0",
-    "symfony/yaml": "^4.1"
+    "symfony/yaml": "^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "8.*",

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -180,7 +180,12 @@ class Generator
         if ($this->yamlCopyRequired) {
             file_put_contents(
                 $this->yamlDocsFile,
-                (new YamlDumper(2))->dump(json_decode(file_get_contents($this->docsFile), true), 20, 0, Yaml::DUMP_OBJECT_AS_MAP ^ Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE)
+                (new YamlDumper(2))->dump(
+                    json_decode(file_get_contents($this->docsFile), true),
+                    20,
+                    0,
+                    Yaml::DUMP_OBJECT_AS_MAP ^ Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE
+                )
             );
         }
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -5,6 +5,7 @@ namespace L5Swagger;
 use Illuminate\Support\Facades\File;
 use L5Swagger\Exceptions\L5SwaggerException;
 use Symfony\Component\Yaml\Dumper as YamlDumper;
+use Symfony\Component\Yaml\Yaml;
 
 class Generator
 {
@@ -179,7 +180,7 @@ class Generator
         if ($this->yamlCopyRequired) {
             file_put_contents(
                 $this->yamlDocsFile,
-                (new YamlDumper(2))->dump(json_decode(file_get_contents($this->docsFile), true), 20)
+                (new YamlDumper(2))->dump(json_decode(file_get_contents($this->docsFile), true), 20, 0, Yaml::DUMP_OBJECT_AS_MAP ^ Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE)
             );
         }
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use L5Swagger\Exceptions\L5SwaggerException;
 use L5Swagger\Generator;
+use Symfony\Component\Yaml\Yaml;
 
 class GeneratorTest extends TestCase
 {
@@ -146,5 +147,18 @@ class GeneratorTest extends TestCase
 
         $this->assertTrue(file_exists($this->jsonDocsFile()));
         $this->assertTrue(file_exists($this->yamlDocsFile()));
+    }
+
+    /** @test */
+    public function canAppropriateYamlType()
+    {
+        $this->setAnnotationsPath();
+
+        Generator::generateDocs();
+
+        $objects = Yaml::parse(file_get_contents($this->yamlDocsFile()), Yaml::PARSE_OBJECT_FOR_MAP);
+
+        $actual = $objects->paths->{'/projects'}->get->security[0]->api_key_security_example;
+        $this->assertIsArray($actual);
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use L5Swagger\Exceptions\L5SwaggerException;
 use L5Swagger\Generator;
+use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
 
 class GeneratorTest extends TestCase
@@ -156,7 +157,7 @@ class GeneratorTest extends TestCase
 
         Generator::generateDocs();
 
-        $objects = Yaml::parse(file_get_contents($this->yamlDocsFile()), Yaml::PARSE_OBJECT_FOR_MAP);
+        $objects = (new Parser())->parse(file_get_contents($this->yamlDocsFile()), Yaml::PARSE_OBJECT_FOR_MAP);
 
         $actual = $objects->paths->{'/projects'}->get->security[0]->api_key_security_example;
         $this->assertIsArray($actual);


### PR DESCRIPTION
According to [swagger-php](https://github.com/zircote/swagger-php/blob/master/src/Annotations/AbstractAnnotation.php#L241), it dumps into YAML with some flags. I tweaked the YAML Dumper and wrote an test case for checking the type.

Please take a look. If you have any concerns, please let me know. 