### PR TITLE
L5 swagger generator throwing laravel file error exception

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -109,6 +109,10 @@ class Generator
             File::deleteDirectory($this->docDir);
         }
 
+        if (File::exists($this->docDir)) {
+            throw new L5SwaggerException('Documentation storage directory or files could not be deleted');
+        }
+
         File::makeDirectory($this->docDir);
 
         return $this;


### PR DESCRIPTION
Better error description for handling creating a directory that's thrown on makeDirectory line when the directory already exists.