### PR TITLE
Fix exception on docs file request without extension.

### DIFF
--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -38,12 +38,12 @@ class SwaggerController extends BaseController
         $documentation = $request->offsetGet('documentation');
         $config = $request->offsetGet('config');
 
-        $extension = 'json';
         $targetFile = $config['paths']['docs_json'] ?? 'api-docs.json';
+        $yaml = false;
 
         if (! is_null($file)) {
             $targetFile = $file;
-            $extension = explode('.', $file)[1];
+            $yaml = explode('.', $file)[1] ?? '' === 'yaml';
         }
 
         $filePath = $config['paths']['docs'].'/'.$targetFile;
@@ -69,7 +69,7 @@ class SwaggerController extends BaseController
 
         $content = File::get($filePath);
 
-        if ($extension === 'yaml') {
+        if ($yaml) {
             return ResponseFacade::make($content, 200, [
                 'Content-Type' => 'application/yaml',
                 'Content-Disposition' => 'inline',

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -42,6 +42,20 @@ class RoutesTest extends TestCase
             ->isOk();
     }
 
+    /** @test */
+    public function itDoesNotThrowExceptionOnDocsFileWithoutExtension(): void
+    {
+        $fileWithoutExtension = 'docs';
+
+        $jsonUrl = route('l5-swagger.default.docs', $fileWithoutExtension);
+
+        $this->crateJsonDocumentationFile();
+
+        $this->get($jsonUrl)
+            ->assertNotFound()
+            ->isOk();
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
This fixes internal server error caused by incorrect extension check for determining if a response should be JSON or YAML.

<details>
<summary>Exception stack</summary>

```
Undefined offset: 1 {"exception":"[object] (ErrorException(code: 0): Undefined offset: 1 at /var/www/html/vendor/darkaonline/l5-swagger/src/Http/Controllers/SwaggerController.php:39)
[stacktrace]
#0 /var/www/html/vendor/darkaonline/l5-swagger/src/Http/Controllers/SwaggerController.php(39): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 [internal function]: L5Swagger\\Http\\Controllers\\SwaggerController->docs()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(54): call_user_func_array()
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(45): Illuminate\\Routing\\Controller->callAction()
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Route.php(239): Illuminate\\Routing\\ControllerDispatcher->dispatch()
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Route.php(196): Illuminate\\Routing\\Route->runController()
#6 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Router.php(685): Illuminate\\Routing\\Route->run()
#7 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(128): Illuminate\\Routing\\Router->Illuminate\\Routing\\{closure}()
#8 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#9 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Router.php(687): Illuminate\\Pipeline\\Pipeline->then()
#10 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Router.php(662): Illuminate\\Routing\\Router->runRouteWithinStack()
#11 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Router.php(628): Illuminate\\Routing\\Router->runRoute()
#12 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Router.php(617): Illuminate\\Routing\\Router->dispatchToRoute()
#13 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(165): Illuminate\\Routing\\Router->dispatch()
#14 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(128): Illuminate\\Foundation\\Http\\Kernel->Illuminate\\Foundation\\Http\\{closure}()
#15 /var/www/html/vendor/inertiajs/inertia-laravel/src/Middleware.php(13): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#16 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Inertia\\Middleware->handle()
#17 /var/www/html/vendor/fruitcake/laravel-cors/src/HandleCors.php(57): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#18 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Fruitcake\\Cors\\HandleCors->handle()
#19 /var/www/html/vendor/fideloper/proxy/src/TrustProxies.php(57): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#20 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Fideloper\\Proxy\\TrustProxies->handle()
#21 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php(63): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#22 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode->handle()
#23 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#24 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(140): Illuminate\\Pipeline\\Pipeline->then()
#25 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(109): Illuminate\\Foundation\\Http\\Kernel->sendRequestThroughRouter()
#26 /var/www/html/vendor/swooletw/laravel-swoole/src/Server/Sandbox.php(257): Illuminate\\Foundation\\Http\\Kernel->handle()
#27 /var/www/html/vendor/swooletw/laravel-swoole/src/Server/Sandbox.php(217): SwooleTW\\Http\\Server\\Sandbox->handleRequest()
#28 /var/www/html/vendor/swooletw/laravel-swoole/src/Server/Sandbox.php(179): SwooleTW\\Http\\Server\\Sandbox->prepareObResponse()
#29 /var/www/html/vendor/swooletw/laravel-swoole/src/Server/Manager.php(225): SwooleTW\\Http\\Server\\Sandbox->run()
#30 {main}
"} 
```

</details>

Test that reproduces this issue also has been added.