### PR TITLE
Fix generating multiple documentations

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -113,16 +113,13 @@ class Generator
             throw new L5SwaggerException('Documentation storage directory is not writable');
         }
 
-        // delete all existing documentation
-        if (File::exists($this->docDir)) {
-            File::deleteDirectory($this->docDir);
+        if (!File::exists($this->docDir)) {
+            File::makeDirectory($this->docDir);
         }
 
-        if (File::exists($this->docDir)) {
-            throw new L5SwaggerException('Documentation storage directory or files could not be deleted');
+        if (!File::exists($this->docDir)) {
+            throw new L5SwaggerException('Documentation storage directory could not be created');
         }
-
-        File::makeDirectory($this->docDir);
 
         return $this;
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -113,11 +113,11 @@ class Generator
             throw new L5SwaggerException('Documentation storage directory is not writable');
         }
 
-        if (!File::exists($this->docDir)) {
+        if (! File::exists($this->docDir)) {
             File::makeDirectory($this->docDir);
         }
 
-        if (!File::exists($this->docDir)) {
+        if (! File::exists($this->docDir)) {
             throw new L5SwaggerException('Documentation storage directory could not be created');
         }
 


### PR DESCRIPTION
Hello,
Thanks for the release of 8.x which provided the long waiting feature of generating multiple docs.
While working with 8.x found that when using the generate command with --all it generates only 1 documentation file. And if I specified the file other files gets deleted.
After a bit of investigation found that `Generator@generateDocs` is being called in the loop for each document which calls `Generator@prepareDirectory` each time causing deleting the directory before generating the next document.
Here's a PR with a quick fix hope it gets approved and merged soon
