### PR TITLE
:bug: #304 Fixing bug on requestInterceptor. Cannot set property 'X-CSRF-TOKEN' of undefined

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -81,9 +81,9 @@ window.onload = function() {
     validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
     oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback') }}",
 
-    requestInterceptor: function() {
-      this.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
-      return this;
+    requestInterceptor: function(request) {
+      request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+      return request;
     },
 
     presets: [


### PR DESCRIPTION
:bug: #304 Fixing bug on requestInterceptor. Cannot set property 'X-CSRF-TOKEN' of undefined

Swagger UI v3.32.0 change requestInterceptor to make it async https://github.com/swagger-api/swagger-ui/releases/tag/v3.32.0

Now we have to get the request headers from the parameter.

Regards.