### PR TITLE
Put apiKey values into header

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -99,6 +99,23 @@ window.onload = function() {
   })
 
   window.ui = ui
+  
+  ui.getConfigs().requestInterceptor = function (request) {
+    if (ui.authSelectors.authorized().size){
+      var authObject = ui.authSelectors.authorized()._root.entries[0];
+      var securityConfig = authObject[1]._root.entries[1][1]._list._tail.array;
+      if (securityConfig[0][1] === 'apiKey' && securityConfig[3][1] === 'header') {
+        var token = authObject[1]._root.entries[2][1];
+        if (authObject[0] === 'Bearer' && !token.startsWith('Bearer ')){
+          token = 'Bearer ' + token;
+        }
+        request.headers[securityConfig[2][1]] = token;
+      }
+    }
+
+    request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+    return request;
+  }
 }
 </script>
 </body>


### PR DESCRIPTION
This code block works with the package's security scheme definition. 

if type=apiKey && in=header then this takes action. 
Key in the header is the same as the "name" parameter, for example, name=Authorization. 
If securityScheme=Bearer it adds a "Bearer" string in front of the bearer token if it doesn't start with it

Example SecuirtyScheme
```
/**
 * @OA\SecurityScheme(
 *   securityScheme="Bearer",
 *   type="apiKey",
 *   description="JWT Bearer token",
 *   name="Authorization",
 *   in="header",
 * )
*/
```

<img width="643" alt="Screen Shot 2020-10-15 at 01 12 21" src="https://user-images.githubusercontent.com/2726365/96051146-98ae5a80-0e83-11eb-841d-1147cf1606ae.png">
