### PR TITLE
Allow PHP8 and add new config param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   - php: 7.3
   - php: 7.4
     env: REPORT_TESTS_COVERAGE=1
+  - php: 8.0
 cache:
   directories:
   - "$HOME/.composer/cache"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "laravel/framework": "^8.0 || ^7.0",
     "zircote/swagger-php": "3.*",
     "swagger-api/swagger-ui": "^3.0",

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -26,6 +26,11 @@ return [
                 'docs_yaml' => 'api-docs.yaml',
 
                 /*
+                * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
                  * Absolute paths to directory containing the swagger annotations are stored.
                 */
                 'annotations' => [

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -147,8 +147,7 @@ class SwaggerController extends BaseController
     {
         $fileUsedForDocs = $config['paths']['docs_json'] ?? 'api-docs.json';
 
-        if (
-            ! empty($config['paths']['format_to_use_for_docs'])
+        if (! empty($config['paths']['format_to_use_for_docs'])
             && $config['paths']['format_to_use_for_docs'] === 'yaml'
             && $config['paths']['docs_yaml']
         ) {

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -136,9 +136,8 @@ class SwaggerController extends BaseController
         return File::get(swagger_ui_dist_path($documentation, 'oauth2-redirect.html'));
     }
 
-
     /**
-     * Generate URL for documentation file
+     * Generate URL for documentation file.
      *
      * @param string $documentation
      *
@@ -149,7 +148,7 @@ class SwaggerController extends BaseController
         $fileUsedForDocs = $config['paths']['docs_json'] ?? 'api-docs.json';
 
         if (
-            !empty($config['paths']['format_to_use_for_docs'])
+            ! empty($config['paths']['format_to_use_for_docs'])
             && $config['paths']['format_to_use_for_docs'] === 'yaml'
             && $config['paths']['docs_yaml']
         ) {
@@ -157,7 +156,7 @@ class SwaggerController extends BaseController
         }
 
         return route(
-            'l5-swagger.' . $documentation . '.docs',
+            'l5-swagger.'.$documentation.'.docs',
             $fileUsedForDocs
         );
     }

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -105,7 +105,19 @@ class SwaggerController extends BaseController
             Request::setTrustedProxies($proxy, Request::HEADER_X_FORWARDED_ALL);
         }
 
-        $urlToDocs = route('l5-swagger.'.$documentation.'.docs', $config['paths']['docs_json'] ?? 'api-docs.json');
+        $fileUsedForDocs = $config['paths']['docs_json'] ?? 'api-docs.json';
+
+        if (!empty($config['paths']['format_to_use_for_docs'])
+            && $config['paths']['format_to_use_for_docs'] === 'yaml'
+            && $config['paths']['docs_yaml']
+        ) {
+            $fileUsedForDocs = $config['paths']['docs_yaml'];
+        }
+
+        $urlToDocs = route(
+            'l5-swagger.'.$documentation.'.docs',
+            $fileUsedForDocs
+        );
 
         // Need the / at the end to avoid CORS errors on Homestead systems.
         return ResponseFacade::make(

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -105,19 +105,7 @@ class SwaggerController extends BaseController
             Request::setTrustedProxies($proxy, Request::HEADER_X_FORWARDED_ALL);
         }
 
-        $fileUsedForDocs = $config['paths']['docs_json'] ?? 'api-docs.json';
-
-        if (! empty($config['paths']['format_to_use_for_docs'])
-            && $config['paths']['format_to_use_for_docs'] === 'yaml'
-            && $config['paths']['docs_yaml']
-        ) {
-            $fileUsedForDocs = $config['paths']['docs_yaml'];
-        }
-
-        $urlToDocs = route(
-            'l5-swagger.'.$documentation.'.docs',
-            $fileUsedForDocs
-        );
+        $urlToDocs = $this->generateDocumentationFileURL($documentation);
 
         // Need the / at the end to avoid CORS errors on Homestead systems.
         return ResponseFacade::make(
@@ -146,5 +134,31 @@ class SwaggerController extends BaseController
         $documentation = $request->offsetGet('documentation');
 
         return File::get(swagger_ui_dist_path($documentation, 'oauth2-redirect.html'));
+    }
+
+
+    /**
+     * Generate URL for documentation file
+     *
+     * @param string $documentation
+     *
+     * @return string
+     */
+    protected function generateDocumentationFileURL(string $documentation)
+    {
+        $fileUsedForDocs = $config['paths']['docs_json'] ?? 'api-docs.json';
+
+        if (
+            !empty($config['paths']['format_to_use_for_docs'])
+            && $config['paths']['format_to_use_for_docs'] === 'yaml'
+            && $config['paths']['docs_yaml']
+        ) {
+            $fileUsedForDocs = $config['paths']['docs_yaml'];
+        }
+
+        return route(
+            'l5-swagger.' . $documentation . '.docs',
+            $fileUsedForDocs
+        );
     }
 }

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -107,7 +107,7 @@ class SwaggerController extends BaseController
 
         $fileUsedForDocs = $config['paths']['docs_json'] ?? 'api-docs.json';
 
-        if (!empty($config['paths']['format_to_use_for_docs'])
+        if (! empty($config['paths']['format_to_use_for_docs'])
             && $config['paths']['format_to_use_for_docs'] === 'yaml'
             && $config['paths']['docs_yaml']
         ) {


### PR DESCRIPTION
This PR adds support for:

- PHP8
- Travis test for PHP8
- New configuration papram `format_to_use_for_docs` which allows set to `json` or `yaml` format to determine which documentation file to use in UI

closes #336, #345, #344