### PR TITLE
PHP8 support in l5-swagger v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     env: CACHE_NAME=SWAGGER
   - php: 7.2
     env: SWAGGER_VERSION=3.0 CACHE_NAME=OPEN_API REPORT_TESTS_COVERAGE=1
+  - php: 8.0
 cache:
   directories:
   - "$HOME/.composer/cache"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "laravel/framework": "^6.0",
     "zircote/swagger-php": "~2.0|3.*",
     "swagger-api/swagger-ui": "^3.0",
-    "symfony/yaml": "^5.0"
+    "symfony/yaml": "^4.1 || ^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "8.*",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "laravel/framework": "^6.0",
     "zircote/swagger-php": "~2.0|3.*",
     "swagger-api/swagger-ui": "^3.0",
-    "symfony/yaml": "^4.1"
+    "symfony/yaml": "^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "8.*",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "laravel/framework": "^6.0",
     "zircote/swagger-php": "~2.0|3.*",
     "swagger-api/swagger-ui": "^3.0",


### PR DESCRIPTION
I made some small changes to get l5-swagger running with Laravel 6 on PHP 8.0

The changes are based on the changes made for php8 support in l5-swagger 7 and 8.