### PR TITLE
Allows addin scan options to OpenApi\scan call, badly needed to add custom query processors

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -97,7 +97,7 @@ return [
 
         'scanOptions' => [
             /**
-             * Custom query path processors classes
+             * Custom query path processors classes.
              *
              * @link https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor
              * @see \OpenApi\scan
@@ -107,19 +107,19 @@ return [
             ],
 
             /**
-             * pattern: string       $pattern File pattern(s) to scan (default: *.php)
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
              * @see \OpenApi\scan
              */
             'pattern' => null,
 
             /**
-             * analyser: defaults to \OpenApi\StaticAnalyser
+             * analyser: defaults to \OpenApi\StaticAnalyser .
              * @see \OpenApi\scan
              */
             'analyser' => null,
 
             /**
-             * analysis: defaults to a new \OpenApi\Analysis
+             * analysis: defaults to a new \OpenApi\Analysis .
              * @see \OpenApi\scan
              */
             'analysis' => null,

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -95,6 +95,36 @@ return [
             'excludes' => [],
         ],
 
+        'scanOptions' => [
+            /**
+             * Custom query path processors classes
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // \App\SwaggerProcessors\SchemaQueryParameter::class,
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php)
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+        ],
+
         /*
          * API security definitions. Will be generated into documentation file.
         */

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -185,13 +185,13 @@ class Generator
             }
         }
 
-        if (!empty($processors)) {
+        if (! empty($processors)) {
             $options['processors'] = $processors;
         }
 
         foreach (['pattern', 'analyser', 'analysis'] as $key) {
             $option = Arr::get($this->scanOptions, $key);
-            if (!empty($option)) {
+            if (! empty($option)) {
                 $option[$key] = $option;
             }
         }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -173,11 +173,6 @@ class Generator
     {
         $options['exclude'] = $this->excludedDirs;
 
-        $paterns = Arr::get($this->scanOptions, 'pattern', []);
-        if (! empty($paterns)) {
-            $options['pattern'] = $paterns;
-        }
-
         $processorClasses = Arr::get($this->scanOptions, 'processors', []);
         $processors = [];
 
@@ -190,8 +185,15 @@ class Generator
             }
         }
 
-        if (! empty($processors)) {
+        if (!empty($processors)) {
             $options['processors'] = $processors;
+        }
+
+        foreach (['pattern', 'analyser', 'analysis'] as $key) {
+            $option = Arr::get($this->scanOptions, $key);
+            if (!empty($option)) {
+                $option[$key] = $option;
+            }
         }
 
         return $options;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -4,13 +4,13 @@ namespace L5Swagger;
 
 use Exception;
 use Illuminate\Support\Arr;
-use OpenApi\Annotations\Server;
-use OpenApi\Annotations\OpenApi;
-use Symfony\Component\Yaml\Yaml;
 use Illuminate\Support\Facades\File;
-use function OpenApi\scan as openApiScan;
 use L5Swagger\Exceptions\L5SwaggerException;
+use OpenApi\Annotations\OpenApi;
+use OpenApi\Annotations\Server;
+use function OpenApi\scan as openApiScan;
 use Symfony\Component\Yaml\Dumper as YamlDumper;
+use Symfony\Component\Yaml\Yaml;
 
 class Generator
 {
@@ -165,20 +165,20 @@ class Generator
     }
 
     /**
-     * Prepares options array for scanning files
+     * Prepares options array for scanning files.
      *
      * @return array
      */
-    protected function getScanOptions() : array
+    protected function getScanOptions(): array
     {
         $options['exclude'] = $this->excludedDirs;
 
         $paterns = Arr::get($this->scanOptions, 'pattern', []);
-        if (!empty($paterns)) {
+        if (! empty($paterns)) {
             $options['pattern'] = $paterns;
         }
 
-        $processorClasses = Arr::get($this->scanOptions, 'processors', [] );
+        $processorClasses = Arr::get($this->scanOptions, 'processors', []);
         $processors = [];
 
         foreach (\OpenApi\Analysis::processors() as $processor) {
@@ -190,7 +190,7 @@ class Generator
             }
         }
 
-        if (!empty($processors)) {
+        if (! empty($processors)) {
             $options['processors'] = $processors;
         }
 

--- a/src/GeneratorFactory.php
+++ b/src/GeneratorFactory.php
@@ -28,6 +28,7 @@ class GeneratorFactory
         $config = $this->configFactory->documentationConfig($documentation);
 
         $paths = $config['paths'];
+        $scanOptions = $config['scanOptions'];
         $constants = $config['constants'] ?? [];
         $yamlCopyRequired = $config['generate_yaml_copy'] ?? false;
 
@@ -40,7 +41,8 @@ class GeneratorFactory
             $paths,
             $constants,
             $yamlCopyRequired,
-            $security
+            $security,
+            $scanOptions
         );
     }
 }


### PR DESCRIPTION
#358 

Here is an example of a custom schema query parameter processor which is badly needed for automation.
 https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor

E.g. in my case I want to add all model fields to resulting swagger files without describing them in comments by hands. I have too many tables and fields for manually creating comments. So this option is badly needed for me.