### PR TITLE
Fix fatal during docs generation/respect "generate_always" flag

### DIFF
--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -72,7 +72,7 @@ class SwaggerController extends BaseController
             }
         }
 
-        if (! File::exists($filePath)) {
+        if (! file_exists($filePath)) {
             abort(404, sprintf('Unable to locate documentation file at: "%s"', $filePath));
         }
 

--- a/src/Http/Controllers/SwaggerController.php
+++ b/src/Http/Controllers/SwaggerController.php
@@ -53,7 +53,7 @@ class SwaggerController extends BaseController
 
         $filePath = $config['paths']['docs'].'/'.$targetFile;
 
-        if ($config['generate_always'] || ! File::exists($filePath)) {
+        if ($config['generate_always']) {
             $generator = $this->generatorFactory->make($documentation);
 
             try {
@@ -70,6 +70,10 @@ class SwaggerController extends BaseController
                     )
                 );
             }
+        }
+
+        if (! File::exists($filePath)) {
+            abort(404, sprintf('Unable to locate documentation file at: "%s"', $filePath));
         }
 
         $content = File::get($filePath);


### PR DESCRIPTION
- fixes fatal when requested `$filePath` is invalid
  If non-existing doc is requested (e.g. https://example.com/docs/foo), an uncaught exception could be raised during `File::get()` call.
  Added a guard to prevent that.

- respect "generate_always" flag
  I think this was introduced back in https://github.com/DarkaOnLine/L5-Swagger/pull/172, presumably before `generate_always` config param was added.
  Imo with addition of `generate_always` this condition became slightly off - if user doesn't want the file to be generated on the fly (`generate_always=false`) l5-swagger shouldn't be ignoring that (by checking if `File::exists()`)