### PR TITLE
Problem with mandatory operationId hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,16 @@ before_script:
 script:
   - chown -R travis:travis /home/travis/build/DarkaOnLine/L5-Swagger
   - mkdir -p tests/storage/logs/test-reports
+  - mkdir -p vendor/orchestra/testbench-core/laravel/vendor/swagger-api
+  - mkdir -p vendor/orchestra/testbench-core/laravel/vendor/swagger-api/swagger-ui
+  - mkdir -p vendor/orchestra/testbench-core/laravel/vendor/swagger-api/swagger-ui/dist
+  - sudo chown -R $USER:$USER vendor/orchestra/testbench-core/laravel/vendor/swagger-api
+  - chmod -R 777 vendor/orchestra/testbench-core/laravel/vendor/swagger-api
+  - ls -al vendor/orchestra/testbench-core/laravel/vendor/swagger-api
   - chmod -R 777 /home/travis/build/DarkaOnLine/L5-Swagger
   - if [ $REPORT_TESTS_COVERAGE != 1 ]; then vendor/bin/phpunit --no-coverage; fi
   - if [ $REPORT_TESTS_COVERAGE == 1 ]; then vendor/bin/phpunit; cp tests/storage/logs/test-reports/clover.xml clover.xml; fi
+  - ls -al vendor/orchestra/testbench-core/laravel/vendor/swagger-api/swagger-ui/dist
 after_success:
   - if [ $REPORT_TESTS_COVERAGE == 1 ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then ./cc-test-reporter after-build -t clover --exit-code $TRAVIS_TEST_RESULT; fi
   - if [ $REPORT_TESTS_COVERAGE == 1 ]; then php vendor/bin/php-coveralls -v; fi

--- a/README.md
+++ b/README.md
@@ -11,12 +11,18 @@ Swagger 2.0 for Laravel >=5.1
 
 This package is a wrapper of [Swagger-php](https://github.com/zircote/swagger-php) and [swagger-ui](https://github.com/swagger-api/swagger-ui) adapted to work with Laravel 5.
 
+#Description
+I found critical bug in the branch 6.0.7. The maintainer of the original package ignored me for 2 months. I was created a new composer package for use as a dependence.
+
+Original package name: `darkaonline/l5-swagger`
+New package name: `smskin/l5-swagger`
+
 Installation
 ============
 
  Laravel          | Swagger UI| OpenAPI Spec compatibility | L5-Swagger
 :-----------------|:----------|:---------------------------|:----------
- 6.0.x            | 3         | 3.0, 2.0                   | `composer require "darkaonline/l5-swagger"`<br><br>:warning: !!! run `composer require 'zircote/swagger-php:2.*'` if you need old **@SWG (SWAGGER annotations)** support. !!!
+ 6.0.x            | 3         | 3.0, 2.0                   | `composer require "smskin/l5-swagger"`<br><br>:warning: !!! run `composer require 'zircote/swagger-php:2.*'` if you need old **@SWG (SWAGGER annotations)** support. !!!
  5.8.x            | 3         | 3.0, 2.0                   | `composer require "darkaonline/l5-swagger:5.8.*"`<br><br>:warning: !!! run `composer require 'zircote/swagger-php:2.*'` if you need old **@SWG (SWAGGER annotations)** support. !!!
  5.7.x OR 5.6.x   | 3         | 3.0, 2.0                   | `composer require "darkaonline/l5-swagger:5.7.*"`<br><br>:warning: !!! run `composer require 'zircote/swagger-php:2.*'` if you need old **@SWG (SWAGGER annotations)** support. !!!
  5.6.x            | 3         | 2.0                        | `composer require "darkaonline/l5-swagger:5.6.*"`

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "darkaonline/l5-swagger",
+  "name": "smskin/l5-swagger",
   "description": "Swagger integration to Laravel 5",
   "keywords": [
     "laravel",

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -233,5 +233,6 @@ return [
      */
     'constants' => [
         'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        'L5_SWAGGER_CONST_GENERATE_OPERATION_ID_HASH' => env('L5_SWAGGER_CONST_GENERATE_OPERATION_ID_HASH', true),
     ],
 ];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -196,7 +196,7 @@ class Generator
     }
 
     /**
-     * Adding the ability to activate and deactivate operationId hashing
+     * Adding the ability to activate and deactivate operationId hashing.
      * @throws \Exception
      */
     private function fixOpenApiAnalysisProcessors()

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -114,6 +114,7 @@ class Generator
     protected function scanFilesForDocumentation()
     {
         if ($this->isOpenApi()) {
+            $this->fixOpenApiAnalysisProcessors();
             $this->swagger = \OpenApi\scan(
                 $this->annotationsDir,
                 ['exclude' => $this->excludedDirs]
@@ -192,5 +193,24 @@ class Generator
     protected function isOpenApi()
     {
         return version_compare(config('l5-swagger.swagger_version'), '3.0', '>=');
+    }
+
+    /**
+     * Adding the ability to activate and deactivate operationId hashing
+     * @throws \Exception
+     */
+    private function fixOpenApiAnalysisProcessors()
+    {
+        $processors = \OpenApi\Analysis::processors();
+        foreach ($processors as $processor){
+            if ($processor instanceof \OpenApi\Processors\OperationId){
+                \OpenApi\Analysis::unregisterProcessor($processor);
+            }
+        }
+        \OpenApi\Analysis::registerProcessor(
+            new \OpenApi\Processors\OperationId(
+                config('l5-swagger.constants.L5_SWAGGER_CONST_GENERATE_OPERATION_ID_HASH', true)
+            )
+        );
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -202,8 +202,8 @@ class Generator
     private function fixOpenApiAnalysisProcessors()
     {
         $processors = \OpenApi\Analysis::processors();
-        foreach ($processors as $processor){
-            if ($processor instanceof \OpenApi\Processors\OperationId){
+        foreach ($processors as $processor) {
+            if ($processor instanceof \OpenApi\Processors\OperationId) {
                 \OpenApi\Analysis::unregisterProcessor($processor);
             }
         }


### PR DESCRIPTION
02.06.2021 the developers of zircote/swagger-php implemented forced hashing of operationId (https://github.com/zircote/swagger-php/commit/d0ec24bc5642ed84172870b2f610964717e84ce5). This innovation broke our code generator. I added the ability to control the hashing of the operationId via the configuration file. Backward compatibility is preserved by enabling hashing by default.