### PR TITLE
Incluido o filtro padrao do swagger para aparecer na pagina

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -240,6 +240,20 @@ return [
         */
         'validator_url' => null,
 
+        'ui' => [
+            'display' => [
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that 
+                 * you can use to filter the tagged operations that are shown. Can be 
+                 * Boolean to enable or disable, or a string, in which case filtering 
+                 * will be enabled using that string as the filter expression. Filtering 
+                 * is case sensitive matching the filter expression anywhere inside 
+                 * the tag. 
+                 */
+                'filter' => true, // true | false
+            ],
+        ],
+
         /*
          * Persist authorization login after refresh browser
          */

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -94,7 +94,7 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-
+    filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
     layout: "StandaloneLayout",
 
     persistAuthorization: {!! config('l5-swagger.defaults.persist_authorization') ? 'true' : 'false' !!},


### PR DESCRIPTION
Incluido o filtro padrao do swagger, uma otima ferramenta de busca para as rotas.

Por padrão, mantive true para ja aparecer, mas ai tem a opção de colocar false