### PR TITLE
Exclude development files from Composer packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,8 @@ ISSUE_TEMPLATE.md   export-ignore
 /tests/             export-ignore
 phpunit.xml         export-ignore
 phpunit.xml.dist    export-ignore
+.github             export-ignore
+/docker/            export-ignore
+CODE_OF_CONDUCT.md  export-ignore
+docker-compose.yml  export-ignore
+Dockerfile          export-ignore


### PR DESCRIPTION
Optimizes the `.gitattributes` file to not export the `.github/` directory and the Docker files for local development. This ensures these files do not end up in the published Composer package.