### PR TITLE
Add PKCE config parameter

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -275,6 +275,11 @@ return [
                  * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
                  */
                 'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                /*
+                 * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                 */
+                'use_pkce_with_authorization_code_grant' => false,
             ],
         ],
         /*

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -276,10 +276,12 @@ return [
                  */
                 'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
 
-                /*
-                 * If set to true, adds PKCE to AuthorizationCodeGrant flow
-                 */
-                'use_pkce_with_authorization_code_grant' => false,
+                'oauth2' => [
+                    /*
+                    * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                    */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
             ],
         ],
         /*

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -67,9 +67,11 @@
 
         window.ui = ui
 
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
         ui.initOAuth({
-            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.use_pkce_with_authorization_code_grant') !!}"
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
         })
+        @endif
     }
 </script>
 </body>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -66,6 +66,10 @@
         })
 
         window.ui = ui
+
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.use_pkce_with_authorization_code_grant') !!}"
+        })
     }
 </script>
 </body>


### PR DESCRIPTION
This PR adds new config option ```use_pkce_with_authorization_code_grant``` with default value set to false. 
This new parameter allows to authorize through Authorization Code Grant with PKCE, because if set to true, it enables swagger-ui option ```usePkceWithAuthorizationCodeGrant```. #485 