### PR TITLE
Documentation config exposed to the Generator

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -92,6 +92,11 @@ class Generator
     protected $fileSystem;
 
     /**
+     * @var array
+     */
+    protected $config;
+
+    /**
      * Generator constructor.
      *
      * @param  array  $paths
@@ -106,7 +111,8 @@ class Generator
         bool $yamlCopyRequired,
         SecurityDefinitions $security,
         array $scanOptions,
-        ?Filesystem $filesystem = null
+        ?Filesystem $filesystem = null,
+        array $config
     ) {
         $this->annotationsDir = $paths['annotations'];
         $this->docDir = $paths['docs'];
@@ -118,6 +124,7 @@ class Generator
         $this->yamlCopyRequired = $yamlCopyRequired;
         $this->security = $security;
         $this->scanOptions = $scanOptions;
+        $this->config = $config;
 
         $this->fileSystem = $filesystem ?? new Filesystem();
     }
@@ -229,7 +236,9 @@ class Generator
             $processors[] = $processor;
             if ($processor instanceof \OpenApi\Processors\BuildPaths) {
                 foreach ($processorClasses as $customProcessor) {
-                    $processors[] = new $customProcessor();
+                    $customProcessorObj = new $customProcessor();
+                    $customProcessorObj->config = $this->config;
+                    $processors[] = $customProcessorObj;
                 }
             }
         }

--- a/src/GeneratorFactory.php
+++ b/src/GeneratorFactory.php
@@ -43,7 +43,9 @@ class GeneratorFactory
             $constants,
             $yamlCopyRequired,
             $security,
-            $scanOptions
+            $scanOptions,
+            null,
+            $config
         );
     }
 }


### PR DESCRIPTION
When in the process of creating a custom processor to filter Annotations based on custom properties, I realized there was no access to the configuration of the documentation itself. This code pushes the individual documentation config to the Generator so that the processor can use it. 
