### PR TITLE
Use Swagger UI >= 4.1.3 due to CVE-2021-46708

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": "^7.2 || ^8.0",
     "laravel/framework": "^10.0 || ^9.0 || >=8.40.0 || ^7.0",
     "zircote/swagger-php": "^3.2.0 || ^4.0.0",
-    "swagger-api/swagger-ui": "^3.0 || ^4.0",
+    "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
     "symfony/yaml": "^5.0 || ^6.0",
     "ext-json": "*"
   },

--- a/src/Http/Controllers/SwaggerAssetController.php
+++ b/src/Http/Controllers/SwaggerAssetController.php
@@ -23,7 +23,7 @@ class SwaggerAssetController extends BaseController
                 $fileSystem->get($path),
                 200,
                 [
-                    'Content-Type' => (pathinfo($asset))['extension'] == 'css'
+                    'Content-Type' => pathinfo($asset)['extension'] == 'css'
                         ? 'text/css'
                         : 'application/javascript',
                 ]

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -26,6 +26,7 @@ class ConfigFactoryTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider configDataProvider
      *
      * @param  array  $data

--- a/tests/ConsoleTest.php
+++ b/tests/ConsoleTest.php
@@ -14,6 +14,7 @@ class ConsoleTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider provideGenerateCommands
      *
      * @param  string  $artisanCommand

--- a/tests/SecurityDefinitionsTest.php
+++ b/tests/SecurityDefinitionsTest.php
@@ -52,6 +52,7 @@ class SecurityDefinitionsTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider provideConfigAndSchemes
      *
      * @param  array  $securitySchemes


### PR DESCRIPTION
Fixes #546

CVE-2021-46708

The swagger-ui-dist package before 4.1.3 for Node.js could allow a remote attacker to hijack the clicking action of the victim. By persuading a victim to visit a malicious Web site, a remote attacker could exploit this vulnerability to hijack the victim's click actions and possibly launch further attacks against the victim.

https://nvd.nist.gov/vuln/detail/CVE-2021-46708