### PR TITLE
Updating symphony version requirements to avoid dependency downgrade in Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "laravel/framework": "^10.0 || ^9.0 || >=8.40.0 || ^7.0",
     "zircote/swagger-php": "^3.2.0 || ^4.0.0",
     "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
-    "symfony/yaml": "^5.0 || ^6.0",
+    "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
When installing a fresh laravel 10 project there is a dependency bug that can be fixed by enabling symphony in a 7.0 version.

![Screenshot 2023-12-07 191820](https://github.com/DarkaOnLine/L5-Swagger/assets/32963009/565c7645-a6f9-42b9-b32b-3cfbf29b785d)

