### PR TITLE
Fix SchemaQueryParameter link

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -120,7 +120,7 @@ return [
             /**
              * Custom query path processors classes.
              *
-             * @link https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
              * @see \OpenApi\scan
              */
             'processors' => [


### PR DESCRIPTION
From broken link:

> https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor

To updated link:

> https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter