### PR TITLE
Allow to pass processors configuration to swagger-php

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -103,6 +103,24 @@ return [
 
         'scanOptions' => [
             /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+                /** Example */
+                /**
+                'operationId.hash' => true,
+                'pathFilter' => [
+                    'tags' => [
+                        '/pets/',
+                        '/store/',
+                    ],
+                ],
+                */
+            ],
+
+            /**
              * analyser: defaults to \OpenApi\StaticAnalyser .
              *
              * @see \OpenApi\scan

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -203,11 +203,9 @@ class Generator
         $generator = new OpenApiGenerator();
 
         // Only from zircote/swagger-php 4
-        if (
-            ! empty($this->scanOptions['default_processors_configuration'])
+        if (! empty($this->scanOptions['default_processors_configuration'])
             && is_array($this->scanOptions['default_processors_configuration'])
-            && method_exists($generator, 'setConfig')
-        ) {
+            && method_exists($generator, 'setConfig')) {
             $generator->setConfig($this->scanOptions['default_processors_configuration']);
         }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -202,6 +202,15 @@ class Generator
     {
         $generator = new OpenApiGenerator();
 
+        // Only from zircote/swagger-php 4
+        if (
+            !empty($this->scanOptions['default_processors_configuration'])
+            && is_array($this->scanOptions['default_processors_configuration'])
+            && method_exists($generator, 'setConfig')
+        ) {
+            $generator->setConfig($this->scanOptions['default_processors_configuration']);
+        }
+
         // OpenApi spec version - only from zircote/swagger-php 4
         if (method_exists($generator, 'setVersion')) {
             $generator->setVersion(

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -205,7 +205,8 @@ class Generator
         // Only from zircote/swagger-php 4
         if (! empty($this->scanOptions['default_processors_configuration'])
             && is_array($this->scanOptions['default_processors_configuration'])
-            && method_exists($generator, 'setConfig')) {
+            && method_exists($generator, 'setConfig')
+        ) {
             $generator->setConfig($this->scanOptions['default_processors_configuration']);
         }
 

--- a/src/L5SwaggerServiceProvider.php
+++ b/src/L5SwaggerServiceProvider.php
@@ -52,6 +52,7 @@ class L5SwaggerServiceProvider extends ServiceProvider
         $this->app->bind(Generator::class, function ($app) {
             $documentation = config('l5-swagger.default');
 
+            /** @var GeneratorFactory $factory */
             $factory = $app->make(GeneratorFactory::class);
 
             return $factory->make($documentation);

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -200,7 +200,9 @@ class GeneratorTest extends TestCase
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
             ->assertSee('operationId')
-            ->assertSee("POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList")
+            ->assertSee(
+                "POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList"
+            )
             ->assertDontSee('getClientsList')
             ->assertStatus(200);
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -118,8 +118,8 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
-            ->assertSee('getClientsList')
             ->assertSee('Get list of products')
+            ->assertSee('getClientsList')
             ->assertStatus(200);
 
         $config = $this->configFactory->documentationConfig();
@@ -128,8 +128,8 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
-            ->assertSee('getClientsList')
             ->assertSee('Get list of products')
+            ->assertSee('getClientsList')
             ->assertStatus(200);
     }
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -200,9 +200,7 @@ class GeneratorTest extends TestCase
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
             ->assertSee('operationId')
-            ->assertSee(
-                "POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList"
-            )
+            ->assertSee("POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList")
             ->assertDontSee('getClientsList')
             ->assertStatus(200);
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -178,6 +178,9 @@ class GeneratorTest extends TestCase
         $cfg['scanOptions']['processors'] = [
             new CleanUnmerged,
         ];
+        $cfg['scanOptions']['default_processors_configuration'] = [
+            'operationId' => ['hash' => false],
+        ];
 
         config(['l5-swagger' => [
             'default' => 'default',
@@ -200,6 +203,8 @@ class GeneratorTest extends TestCase
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
             ->assertSee('getProductsList')
+            ->assertSee('operationId')
+            ->assertSee("POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList")
             ->assertDontSee('getClientsList')
             ->assertStatus(200);
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -118,7 +118,6 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
-            ->assertSee('getProductsList')
             ->assertSee('getClientsList')
             ->assertStatus(200);
 
@@ -128,7 +127,6 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
-            ->assertSee('getProductsList')
             ->assertSee('getClientsList')
             ->assertStatus(200);
     }
@@ -158,7 +156,6 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
-            ->assertSee('getProductsList')
             ->assertDontSee('getClientsList')
             ->assertStatus(200);
     }
@@ -202,7 +199,6 @@ class GeneratorTest extends TestCase
             ->assertSee('3.1.0')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
-            ->assertSee('getProductsList')
             ->assertSee('operationId')
             ->assertSee("POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList")
             ->assertDontSee('getClientsList')

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -119,6 +119,7 @@ class GeneratorTest extends TestCase
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
             ->assertSee('getClientsList')
+            ->assertSee('Get list of products')
             ->assertStatus(200);
 
         $config = $this->configFactory->documentationConfig();
@@ -128,6 +129,7 @@ class GeneratorTest extends TestCase
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
             ->assertSee('getClientsList')
+            ->assertSee('Get list of products')
             ->assertStatus(200);
     }
 
@@ -156,6 +158,7 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertSee('my-default-host.com')
             ->assertSee('getProjectsList')
+            ->assertSee('Get list of products')
             ->assertDontSee('getClientsList')
             ->assertStatus(200);
     }

--- a/tests/storage/annotations/OpenApi/Products/L5SwaggerAnnotationsExampleProducts.php
+++ b/tests/storage/annotations/OpenApi/Products/L5SwaggerAnnotationsExampleProducts.php
@@ -7,7 +7,6 @@ class L5SwaggerAnnotationsExampleProducts
     /**
      * @OA\Post(
      *      path="/products",
-     *      operationId="getProductsList",
      *      tags={"Products"},
      *      summary="Get list of products",
      *      description="Returns list of products",


### PR DESCRIPTION
Allow to pass processors configuration to [swagger-php](https://zircote.github.io/swagger-php/reference/processors.html#programmatically-with-php)

closes #590 