### PR TITLE
Fix Bug of L5_SWAGGER_UI_ASSETS_PATH(.env) not working

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -21,6 +21,11 @@ return [
                 'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
 
                 /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
                  * File name of the generated json documentation file
                  */
                 'docs_json' => 'api-docs.json',
@@ -87,11 +92,6 @@ return [
              * Edit to set the api's base path
              */
             'base' => env('L5_SWAGGER_BASE_PATH', null),
-
-            /*
-             * Edit to set path where swagger ui assets should be stored
-             */
-            'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
 
             /*
              * Absolute path to directories that should be excluded from scanning


### PR DESCRIPTION
After a lot of hours trying, I found that there is a bug while someone try to set a custom path for swagger-ui assets.