### PR TITLE
change summary text color for dark mode

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -109,6 +109,9 @@
             #dark-mode svg:not(:root){
                 fill: #e7e7e7;
             }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
         </style>
     @endif
 </head>


### PR DESCRIPTION
In dark mode ,Path summary don't show .Actually it was show but background color and text color are same . 
![image](https://github.com/user-attachments/assets/16fef50b-950d-43f2-a6c6-354cb7aa2e14)
