### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,7 +12,7 @@ if (! function_exists('swagger_ui_dist_path')) {
      *
      * @throws L5SwaggerException
      */
-    function swagger_ui_dist_path(string $documentation, string $asset = null): string
+    function swagger_ui_dist_path(string $documentation, ?string $asset = null): string
     {
         $allowedFiles = [
             'favicon-16x16.png',


### PR DESCRIPTION
PHP: 8.4
L5 Swagger: 9.0.0

I catch warnings:
```
Deprecated: swagger_ui_dist_path(): Implicitly marking parameter $asset as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/darkaonline/l5-swagger/src/helpers.php on line 15
```
[deprecate-implicitly-nullable-types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

This PR adds nullable type to parameters