### PR TITLE
Remove unused Swagger UI map files

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -19,13 +19,9 @@ if (! function_exists('swagger_ui_dist_path')) {
             'favicon-32x32.png',
             'oauth2-redirect.html',
             'swagger-ui-bundle.js',
-            'swagger-ui-bundle.js.map',
             'swagger-ui-standalone-preset.js',
-            'swagger-ui-standalone-preset.js.map',
             'swagger-ui.css',
-            'swagger-ui.css.map',
             'swagger-ui.js',
-            'swagger-ui.js.map',
         ];
 
         $defaultPath = 'vendor/swagger-api/swagger-ui/dist/';


### PR DESCRIPTION
The .map URLs are generating errors in the log file. I checked Swagger UI, and these files are excluded from the dist folders.

<img width="1304" height="354" alt="Screenshot 2025-12-22 154714" src="https://github.com/user-attachments/assets/23bfee65-a109-463c-ab05-2d11b3f63fcd" />
 