### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/test-config.yml
+++ b/.github/workflows/test-config.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ '8.3' , '8.4' , '8.5' ]
+        php: [ '8.2', '8.3' , '8.4' , '8.5' ]
         l5-swagger-flags:  ['swagger-php-latest']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.l5-swagger-flags }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -33,7 +33,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/test-config.yml
+++ b/.github/workflows/test-config.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ '8.2', '8.3' ]
+        php: [ '8.3' , '8.4' , '8.5' ]
         l5-swagger-flags:  ['swagger-php-latest']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.l5-swagger-flags }}

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     }
   },
   "require": {
-    "php": "^8.3",
+    "php": "^8.2",
     "laravel/framework": "^13.0 || ^12.1 || ^11.44",
     "zircote/swagger-php": "^6.0",
     "swagger-api/swagger-ui": ">=5.18.3",

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     }
   },
   "require": {
-    "php": "^8.2",
-    "laravel/framework": "^12.1 || ^11.44",
+    "php": "^8.3",
+    "laravel/framework": "^13.0 || ^12.1 || ^11.44",
     "zircote/swagger-php": "^6.0",
     "swagger-api/swagger-ui": ">=5.18.3",
     "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
@@ -42,7 +42,7 @@
   "require-dev": {
     "phpunit/phpunit": "^11.0",
     "mockery/mockery": "1.*",
-    "orchestra/testbench": "^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+    "orchestra/testbench": "^11.0 || ^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
     "php-coveralls/php-coveralls": "^2.0",
     "phpstan/phpstan": "^2.1"
   },


### PR DESCRIPTION
- Add `laravel/framework ^13.0` to supported versions
- Add `orchestra/testbench ^11.0` for Laravel 13 testing
- Bump minimum PHP requirement to `^8.3`
  - Laravel 13 does not support PHP 8.2
- Update CI PHP matrix to 8.3, 8.4, 8.5
