### PR TITLE
Add extension points for custom OpenApi\Generator instantiation

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -184,9 +184,14 @@ class Generator
      *
      * @return OpenApiGenerator
      */
+    protected function newOpenApiGenerator(): OpenApiGenerator
+    {
+        return new OpenApiGenerator();
+    }
+
     protected function createOpenApiGenerator(): OpenApiGenerator
     {
-        $generator = new OpenApiGenerator();
+        $generator = $this->newOpenApiGenerator();
 
         if (! empty($this->scanOptions['default_processors_configuration'])
             && is_array($this->scanOptions['default_processors_configuration'])

--- a/src/GeneratorFactory.php
+++ b/src/GeneratorFactory.php
@@ -32,6 +32,27 @@ class GeneratorFactory
 
         $security = new SecurityDefinitions($secSchemesConfig, $secConfig);
 
+        return $this->createGenerator(
+            $paths,
+            $constants,
+            $yamlCopyRequired,
+            $security,
+            $scanOptions
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $paths
+     * @param  array<string>  $constants
+     * @param  array<string,mixed>  $scanOptions
+     */
+    protected function createGenerator(
+        array $paths,
+        array $constants,
+        bool $yamlCopyRequired,
+        SecurityDefinitions $security,
+        array $scanOptions
+    ): Generator {
         return new Generator(
             $paths,
             $constants,

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -7,9 +7,12 @@ use L5Swagger\Exceptions\L5SwaggerException;
 use L5Swagger\Generator;
 use L5Swagger\GeneratorFactory;
 use L5Swagger\L5SwaggerServiceProvider;
+use L5Swagger\ConfigFactory;
+use L5Swagger\SecurityDefinitions;
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
+use OpenApi\Generator as OpenApiGenerator;
 use OpenApi\OpenApiException;
 use OpenApi\Processors\AugmentParameters;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -222,6 +225,55 @@ class GeneratorTest extends TestCase
             ->assertSee('operationId')
             ->assertSee("POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList")
             ->assertDontSee('getClientsList')
+            ->assertStatus(200);
+    }
+
+    /**
+     * @throws L5SwaggerException
+     */
+    public function testCanGenerateWithCustomGeneratorFactory(): void
+    {
+        $app = $this->app;
+
+        if (! $app instanceof \Illuminate\Foundation\Application) {
+            throw new \RuntimeException('Application is not set');
+        }
+
+        $this->setAnnotationsPath();
+
+        $customFactoryCalled = false;
+
+        $factory = new class($app->make(ConfigFactory::class)) extends GeneratorFactory {
+            protected function createGenerator(
+                array $paths,
+                array $constants,
+                bool $yamlCopyRequired,
+                SecurityDefinitions $security,
+                array $scanOptions
+            ): Generator {
+                return new class($paths, $constants, $yamlCopyRequired, $security, $scanOptions) extends Generator {
+                    protected function newOpenApiGenerator(): OpenApiGenerator
+                    {
+                        return new OpenApiGenerator();
+                    }
+                };
+            }
+        };
+
+        $app->bind(Generator::class, function () use ($factory, &$customFactoryCalled) {
+            $customFactoryCalled = true;
+
+            return $factory->make(config('l5-swagger.default'));
+        });
+
+        $generator = $app->make(Generator::class);
+        $generator->generateDocs();
+
+        $this->assertTrue($customFactoryCalled);
+        $this->assertFileExists($this->jsonDocsFile());
+
+        $this->get(route('l5-swagger.default.docs'))
+            ->assertSee('L5 Swagger')
             ->assertStatus(200);
     }
 

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -3,11 +3,11 @@
 namespace Tests\Unit;
 
 use Illuminate\Http\Request;
+use L5Swagger\ConfigFactory;
 use L5Swagger\Exceptions\L5SwaggerException;
 use L5Swagger\Generator;
 use L5Swagger\GeneratorFactory;
 use L5Swagger\L5SwaggerServiceProvider;
-use L5Swagger\ConfigFactory;
 use L5Swagger\SecurityDefinitions;
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
@@ -243,7 +243,8 @@ class GeneratorTest extends TestCase
 
         $customFactoryCalled = false;
 
-        $factory = new class($app->make(ConfigFactory::class)) extends GeneratorFactory {
+        $factory = new class($app->make(ConfigFactory::class)) extends GeneratorFactory
+        {
             protected function createGenerator(
                 array $paths,
                 array $constants,
@@ -251,7 +252,8 @@ class GeneratorTest extends TestCase
                 SecurityDefinitions $security,
                 array $scanOptions
             ): Generator {
-                return new class($paths, $constants, $yamlCopyRequired, $security, $scanOptions) extends Generator {
+                return new class($paths, $constants, $yamlCopyRequired, $security, $scanOptions) extends Generator
+                {
                     protected function newOpenApiGenerator(): OpenApiGenerator
                     {
                         return new OpenApiGenerator();


### PR DESCRIPTION
Related to #667 

## Summary
  - Add `Generator::newOpenApiGenerator()` method to isolate OpenApi\Generator creation
  - Add `GeneratorFactory::createGenerator()` method to allow custom Generator instantiation
  - These two methods together allow customizing the OpenApi\Generator instance without
    duplicating the entire Generator or GeneratorFactory class
    
## Motivation
Projects that need a pre-configured `OpenApi\Generator` (e.g. via `OpenApiBuilder` from
openapi-extras) currently have to override both `GeneratorFactory` and `Generator` entirely.
With these extension points, a single custom factory suffices:
```php
class CustomGeneratorFactory extends GeneratorFactory
{
    protected function createGenerator(
        array $paths,
        array $constants,
        bool $yamlCopyRequired,
        SecurityDefinitions $security,
        array $scanOptions
    ): Generator {
        return new class($paths, $constants, $yamlCopyRequired, $security, $scanOptions) extends Generator
            protected function newOpenApiGenerator(): OpenApiGenerator
            {
                return new OpenApiGenerator();
            }
        };
    }
}
```