### PR TITLE
Support positioning custom processors relative to any existing processor

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -135,13 +135,19 @@ return [
             'analysis' => null,
 
             /**
-             * Custom query path processors classes.
+             * Custom processors.
+             *
+             * Each entry can be:
+             * - A class name or instance (inserted after BuildPaths by default)
+             * - An array with 'class' and 'after' keys for precise positioning:
+             *   ['class' => MyProcessor::class, 'after' => SomeProcessor::class]
              *
              * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
              * @see \OpenApi\scan
              */
             'processors' => [
-                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+                // \App\SwaggerProcessors\SchemaQueryParameter::class,
+                // ['class' => \App\SwaggerProcessors\Custom::class, 'after' => \OpenApi\Processors\AugmentSchemas::class],
             ],
 
             /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -215,23 +215,36 @@ class Generator
      */
     protected function setProcessors(OpenApiGenerator $generator): void
     {
-        $processorClasses = Arr::get($this->scanOptions, self::SCAN_OPTION_PROCESSORS, []);
-        $newPipeLine = [];
+        $processorConfigs = Arr::get($this->scanOptions, self::SCAN_OPTION_PROCESSORS, []);
 
+        if (empty($processorConfigs)) {
+            return;
+        }
+
+        $normalizedConfigs = [];
+        foreach ($processorConfigs as $config) {
+            if (is_array($config)) {
+                $normalizedConfigs[] = $config;
+            } else {
+                $normalizedConfigs[] = ['class' => $config, 'after' => \OpenApi\Processors\BuildPaths::class];
+            }
+        }
+
+        $newPipeLine = [];
         $generator->getProcessorPipeline()->walk(
-            function (callable $pipe) use ($processorClasses, &$newPipeLine) {
+            function (callable $pipe) use ($normalizedConfigs, &$newPipeLine) {
                 $newPipeLine[] = $pipe;
-                if ($pipe instanceof \OpenApi\Processors\BuildPaths) {
-                    foreach ($processorClasses as $customProcessor) {
-                        $newPipeLine[] = new $customProcessor();
+                foreach ($normalizedConfigs as $entry) {
+                    $after = $entry['after'];
+                    if ($pipe instanceof $after) {
+                        $processor = $entry['class'];
+                        $newPipeLine[] = is_string($processor) ? new $processor() : $processor;
                     }
                 }
             }
         );
 
-        if (! empty($newPipeLine)) {
-            $generator->setProcessorPipeline(new Pipeline($newPipeLine));
-        }
+        $generator->setProcessorPipeline(new Pipeline($newPipeLine));
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -223,11 +223,9 @@ class Generator
 
         $normalizedConfigs = [];
         foreach ($processorConfigs as $config) {
-            if (is_array($config)) {
-                $normalizedConfigs[] = $config;
-            } else {
-                $normalizedConfigs[] = ['class' => $config, 'after' => \OpenApi\Processors\BuildPaths::class];
-            }
+            $normalizedConfigs[] = is_array($config)
+                ? $config
+                : ['class' => $config, 'after' => \OpenApi\Processors\BuildPaths::class];
         }
 
         $newPipeLine = [];

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -260,7 +260,7 @@ class GeneratorTest extends TestCase
             ->assertSee('L5 Swagger')
             ->assertStatus(200);
     }
-  
+
     /**
      * @throws L5SwaggerException
      */

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -12,6 +12,7 @@ use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
 use OpenApi\OpenApiException;
 use OpenApi\Processors\AugmentParameters;
+use OpenApi\Processors\AugmentSchemas;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\Yaml\Parser;
@@ -222,6 +223,38 @@ class GeneratorTest extends TestCase
             ->assertSee('operationId')
             ->assertSee("POST::/products::Tests\\\storage\\\annotations\\\OpenApi\\\Products\\\L5SwaggerAnnotationsExampleProducts::getProductsList")
             ->assertDontSee('getClientsList')
+            ->assertStatus(200);
+    }
+
+    /**
+     * @throws L5SwaggerException
+     */
+    public function testCanGenerateWithProcessorPositioning(): void
+    {
+        $cfg = config('l5-swagger.documentations.default');
+
+        $cfg['scanOptions'] = [
+            'processors' => [
+                new AugmentParameters(),
+                ['class' => AugmentSchemas::class, 'after' => AugmentParameters::class],
+            ],
+            'default_processors_configuration' => ['operationId' => ['hash' => false]],
+        ];
+
+        config(['l5-swagger' => [
+            'default' => 'default',
+            'documentations' => ['default' => $cfg],
+            'defaults' => config('l5-swagger.defaults'),
+        ]]);
+
+        $this->setAnnotationsPath();
+
+        $this->generator->generateDocs();
+
+        $this->assertFileExists($this->jsonDocsFile());
+
+        $this->get(route('l5-swagger.default.docs'))
+            ->assertSee('L5 Swagger')
             ->assertStatus(200);
     }
 


### PR DESCRIPTION
Relates to #667 

## Summary
- Custom processors in `scanOptions.processors` can now specify where they should be
  inserted in the pipeline using an array form: `['class' => ..., 'after' => ...]`
- Plain string/instance entries retain backwards-compatible behavior (inserted after BuildPaths)

## Example
```php
'processors' => [
    // Inserted after BuildPaths (default, backwards compatible)
    MyProcessor::class,

    // Inserted after a specific processor
    ['class' => AnotherProcessor::class, 'after' => AugmentSchemas::class],
],
```
